### PR TITLE
support for records

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,31 @@ const store = compose(autoRehydrate(), createStore)(reducer)
 
 persistStore(store, {transforms: [immutableTransform()]})
 ```
+
+### Usage with Records
+By default, immutable [`Record`s](https://facebook.github.io/immutable-js/docs/#/Record) will be persisted and restored as `Map`s, because the library has no way of knowing what your `Record` constructor looks like. To change this behavior and allow a `Record` to be persisted and restored as a `Record` instance, you'll need to do two things:
+
+1. Add a name attribute to your record (this is the second argument to a `Record`'s constructor).
+2. Pass your `Record` constructor to the transformer's `withRecords()` function to generate a transformer capable of serializing and deserializing the record.
+
+Minimal example:
+```js
+import { compose } from 'redux'
+import { persistStore, autoRehydrate } from 'redux-persist'
+import immutableTransform from 'redux-persist-transform-immutable'
+
+const reducer = combineReducers(reducers)
+const store = compose(autoRehydrate(), createStore)(reducer)
+
+const MyRecord = Record({
+  foo: 'null'
+}, 'MyRecord') // <- Be sure to add a name field to your record 
+
+persistStore(
+  store,
+  {
+    transforms: [immutableTransform({records: [MyRecord]})]
+  }
+)
+
+```

--- a/index.js
+++ b/index.js
@@ -2,16 +2,21 @@ var transit = require('transit-immutable-js')
 var reduxPersist = require('redux-persist')
 
 module.exports = function (config) {
+  var transitInstance = transit
+  if (config.records) {
+    transitInstance = transit.withRecords(config.records)
+  }
+
   return reduxPersist.createTransform(
     function(state){
       if(state && typeof state === 'object'){
-        return transit.toJSON(state)
+        return transitInstance.toJSON(state)
       }
       return state
     },
     function(raw){
       if(typeof raw === 'string'){
-        return transit.fromJSON(raw)
+        return transitInstance.fromJSON(raw)
       }
       return raw
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "immutable": ">= 3",
     "transit-js": ">= 0.8",
-    "transit-immutable-js": ">= 0.2"
+    "transit-immutable-js": ">= 0.5"
   },
   "peerDependencies": {
     "redux-persist": ">=3.0.0"


### PR DESCRIPTION
This PR adds support for automatically serializing/deserializing Record instances. It's built on the recently-added Record support in [transit-immutable-js](https://github.com/glenjamin/transit-immutable-js). I have verified that this functionality works to persist and restore Record objects in a real project.

For an overview and description of how this functionality is implemented, see my additions to the README.