### PR TITLE
Clarify README around non-Immutable object parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,35 @@ persistStore(
 )
 
 ```
+
+### Avoiding conflicts with non-Immutable objects
+
+By default, `redux-persist-immutable-transform` will attempt to serialize and deserialize *all* passed objects using `transit-immutable-js`. This can pose a problem if you are also using, for example, plain string objects in your state, because the deserialization will see a regular (non-JSON) string and try to parse it into an object, but will fail. You can utilize the `config` object passed to the constructor to either whitelist or blacklist entries that should or should not be treated by the transformer.
+
+Example state object:
+
+```js
+state = {
+  username: 'john',
+  imageUri: 'images/profilePic.png',
+  friends: Immutable.List([ ... ])
+}
+```
+
+Set up the transformer to ignore the string-based state properties:
+
+```js
+persistStore(store, {
+  transforms: [immutableTransform({
+    blacklist: ['username', 'imageUri']
+  })]
+})
+
+/* OR */
+
+persistStore(store, {
+  transforms: [immutableTransform({
+    whitelist: ['friends']
+  })]
+})
+```


### PR DESCRIPTION
I spent a good chunk of time trying to figure out why I was getting weird errors on the strings in my state after persisting data, and finally realized it was because the transformer was trying to deal with those as well. The functionality for fixing this is already there, but it could be very helpful to future visitors to have this use case called out, as I imagine it is pretty common.

Thanks for the great tool!