### PR TITLE
Use removedev-serialize instead of transit

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,11 @@
-var transit = require('transit-immutable-js')
+var Immutable = require('immutable')
+var Serialize = require('remotedev-serialize')
 var reduxPersist = require('redux-persist')
 
 module.exports = function (config) {
   config = config || {}
 
-  var transitInstance = transit
-  if (config.records) {
-    transitInstance = transit.withRecords(config.records)
-  }
+  var serializer =  Serialize.immutable(Immutable, config.records)
 
-  return reduxPersist.createTransform(
-    function(state){
-      return transitInstance.toJSON(state)
-    },
-    function(raw){
-      return transitInstance.fromJSON(raw)
-    },
-    config
-  )
+  return reduxPersist.createTransform(serializer.stringify, serializer.parse, config)
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "echo \"no test specified\" && exit 0"
   },
   "dependencies": {
-    "transit-immutable-js": "^0.7.0",
-    "transit-js": "^0.8.846"
+    "remotedev-serialize": "^0.1.0"
   },
   "peerDependencies": {
     "redux-persist": "^4.0.0",


### PR DESCRIPTION
This will reduce bundle size, and theoretically make it compatible with immutable 4 as well.

Tested by yarn-linking this part to my main project, and everything worked.