### PR TITLE
allow redux-persist v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "remotedev-serialize": "^0.1.0"
   },
   "peerDependencies": {
-    "redux-persist": "^4.0.0",
+    "redux-persist": ">= 4 <= 5",
     "immutable": ">= 3"
   },
   "repository": {


### PR DESCRIPTION
This module supports it but the current peer dependency causes the following error when redux-persist 5 is installed:

```
npm ERR! peerinvalid The package redux-persist@5.4.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer redux-persist-transform-immutable@4.3.0 wants redux-persist@^4.0.0
```