### PR TITLE
Add package lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "redux-persist-transform-immutable",
+  "version": "5.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "jsan": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/jsan/-/jsan-3.1.9.tgz",
+      "integrity": "sha1-JwVnbBBY8KfZrCZq0Daldpz6fJY="
+    },
+    "remotedev-serialize": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.4.tgz",
+      "integrity": "sha512-xFUjsHi/qY14uJmyk1uZynRJli5j5JdTE8Qm2jNCHMQVRSdKRqGh2vqQh6eoOiRX4K8yxjEXqtcxd4Oj2dmK4Q==",
+      "requires": {
+        "jsan": "3.1.9"
+      }
+    }
+  }
+}


### PR DESCRIPTION
We had a subtle issue sting us today whereby persisted `Date` objects were getting deserialised as `String`'s incorrectly.

It turns out that a new version of `remotedev-serialize` released two days ago (`0.1.4`) has fixed the issue. We happened to have version `0.1.3` locally because we had added this repo to our deps on Friday when `0.1.3` was the latest and greatest.

As this repo currently doesn't have a lock file a remove/re-add today resulted in it picking up the latest version of `remotedev-serialize` indirectly but we couldn't think of a reason why `redux-persist-transform-immutable` didn't already have a lock file to guard against issues like this happening again in the future, hence this PR.

Below are some example demonstrating the issue with `remotedev-serialize`. In them we drive it the same way this transform does. The only difference between the two examples is what version of `remotedev-serialize` is being used. Note how the output to the console varies between the two versions.

`0.1.3` example: https://codesandbox.io/s/93m31m9rvw
`0.1.4` example: https://codesandbox.io/s/n15wxnyn9l

**TL;DR:**
We were using this library and one of its dependencies released a patch version with a breaking change in it. As this library has no lockfile what version you download depends on the time its installed.