### PR TITLE
Update peer dependency on redux-persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "remotedev-serialize": "^0.1.0"
   },
   "peerDependencies": {
-    "redux-persist": "^4.0.0",
+    "redux-persist": ">= 4.0.0",
     "immutable": ">= 3"
   },
   "repository": {


### PR DESCRIPTION
This package is working in production for us with latest redux-persist.

Would be great to remove install errors/warnings due to a mismatched peer dependency. :pray: